### PR TITLE
Add example of expected output with URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ docker: Error response from daemon: user declined directory sharing C:\path\to\d
 you should open the Docker dashboard, and then under Settings -> Resources ->
 FileSharing, add the appropriate path.
 
+Once the server starts you should see the URL needed to access it,
+followed by some lines of Jupyter log output, for example:
+<pre>
+ -> Connect to notebook with URL:
+
+        <strong>http://localhost:59169/?token=C1atgmXc9IJGXCZy</strong>
+
+    Tip: to open in browser, triple-click the URL, right-click, choose "Open"
+
+[I 2024-08-08 13:13:18.953 ServerApp] jupyter_lsp | extension was successfully linked.
+[I 2024-08-08 13:13:18.959 ServerApp] jupyter_server_terminals | extension was successfully linked.
+[I 2024-08-08 13:13:18.969 ServerApp] jupyterlab | extension was successfully linked.
+...
+[I 2024-08-08 13:13:19.471 ServerApp] Serving notebooks from local directory: /workspace
+[I 2024-08-08 13:13:19.472 ServerApp] Jupyter Server 2.14.0 is running at:
+[I 2024-08-08 13:13:19.472 ServerApp] http://localhost:59169/?token=C1atgmXc9IJGXCZy
+[I 2024-08-08 13:13:19.472 ServerApp]     http://127.0.0.1:59169/lab?token=...
+[I 2024-08-08 13:13:19.472 ServerApp] Use Control-C to stop this server and shut down all kernels.
+</pre>
+
 
 ## How to cite
 


### PR DESCRIPTION
We've had at least [one user][1] not spot the URL in the output because of all the Jupyter log noise and then get confused. Hopefully providing an example of what it looks like will make this less likely to happen.

[1]: https://bennettoxford.slack.com/archives/C061V4T8R0S/p1723122469052279?thread_ts=1722980505.216289&cid=C061V4T8R0S